### PR TITLE
Fixing minor disk naming issue when running read-only dd test.

### DIFF
--- a/pre-install/disk-test.sh
+++ b/pre-install/disk-test.sh
@@ -50,7 +50,7 @@ fi
 echo Scrutinize this list carefully!!; exit #Comment out exit after list is vetted
 
 #read-only dd test, possible even after MFS is in place
-#for i in $disks; do dd of=/dev/null if=/dev/$i iflag=direct bs=1M count=1000 & done; exit
+#for i in $disks; do dd of=/dev/null if=$i iflag=direct bs=1M count=1000 & done; exit
 
 set -x
 for disk in $disks; do


### PR DESCRIPTION
If this line is uncommented for a read-only `dd` test as is, I encounter a disk naming issue resembling the following:

    $ sudo ./cluster-validation/pre-install/disk-test.sh
    Unused disks:  /dev/sdi /dev/sdj /dev/sdk /dev/sdl /dev/sdd /dev/sdf /dev/sda /dev/sdb /dev/sde /dev/sdc /dev/sdg /dev/sdh
    Scrutinize this list carefully!!
    dd of=/dev/null if=/dev//dev/sdi iflag=direct bs=1M count=1000
    dd of=/dev/null if=/dev//dev/sdj iflag=direct bs=1M count=1000
    dd of=/dev/null if=/dev//dev/sdk iflag=direct bs=1M count=1000
    dd of=/dev/null if=/dev//dev/sdl iflag=direct bs=1M count=1000
    dd of=/dev/null if=/dev//dev/sdd iflag=direct bs=1M count=1000
    dd of=/dev/null if=/dev//dev/sdf iflag=direct bs=1M count=1000
    dd of=/dev/null if=/dev//dev/sda iflag=direct bs=1M count=1000
    dd of=/dev/null if=/dev//dev/sdb iflag=direct bs=1M count=1000
    dd of=/dev/null if=/dev//dev/sde iflag=direct bs=1M count=1000
    dd of=/dev/null if=/dev//dev/sdc iflag=direct bs=1M count=1000
    dd of=/dev/null if=/dev//dev/sdg iflag=direct bs=1M count=1000
    dd of=/dev/null if=/dev//dev/sdh iflag=direct bs=1M count=1000

Since `/dev` is already prepended in your `$disks` variable, we don't need to prepend it again within the for loop.