### PR TITLE
Fix syntax error of network-test.sh

### DIFF
--- a/pre-install/network-test.sh
+++ b/pre-install/network-test.sh
@@ -105,9 +105,9 @@ for node in "${half2[@]}"; do
        ssh $node "arp -na | awk '{print \$NF}' | sort -u | xargs -l ifconfig | grep errors"
        echo
        ;;
+  esac
   #catch all client PIDs ($!)
   clients="$clients $!"
-  esac
   ((i++))
   #ssh $node 'echo $[4*1024] $[1024*1024] $[4*1024*1024] | tee /proc/sys/net/ipv4/tcp_wmem > /proc/sys/net/ipv4/tcp_rmem'
 done


### PR DESCRIPTION
I met syntax error of latest network-test.sh.

```
/root/cluster-validation/pre-install/network-test.sh: line 109: syntax error near unexpected token `newline'
/root/cluster-validation/pre-install/network-test.sh: line 109: `  clients="$clients $!"'
```

