### PR TITLE
Update disk-test.sh

### DIFF
--- a/pre-install/disk-test.sh
+++ b/pre-install/disk-test.sh
@@ -69,6 +69,7 @@ find_unused_disks() {
          grep $dev /opt/mapr/conf/disktab &>/dev/null && continue #Looks like part of MapR disk set already
          lsof $dev && continue #Looks like something has device open
       fi
+      cryptsetup isLuks $dev && continue #device is part of encrypted partition
       disklist="$disklist $dev" #Survived all filters, add device to the list of unused disks
    done
 

--- a/pre-install/summIOzone.sh
+++ b/pre-install/summIOzone.sh
@@ -3,7 +3,7 @@
 # script which summarizes iozone results on a set of disks
 # iozone results presumed to be in current folder in .log files
 # updated to work with AWS
-
+# 20171020 R.Itäpuro initialize svals variable to get correct CV values
 files=$(ls *-iozone.log 2>/dev/null)
 [ -n "$files" ] || { echo No iozone.log files found; exit 1; }
 
@@ -44,6 +44,7 @@ cat *-iozone.log | gawk '
      printf "%-7s %6d\n", "mean:", swavg
      printf "%-7s %6d\n", "min:", swmin
      printf "%-7s %6d\n", "max:", swmax
+     svals = 0
      for (val in swvals) {
        svals += (swvals[val] - swavg) ** 2
      }
@@ -57,6 +58,7 @@ cat *-iozone.log | gawk '
      printf "%-7s %6d\n", "mean:", sravg
      printf "%-7s %6d\n", "min:", srmin
      printf "%-7s %6d\n", "max:", srmax
+     svals = 0
      for (val in srvals) {
        svals += (srvals[val] - sravg) ** 2
      }
@@ -70,6 +72,7 @@ cat *-iozone.log | gawk '
      printf "%-7s %6d\n", "mean:", rwavg
      printf "%-7s %6d\n", "min:", rwmin
      printf "%-7s %6d\n", "max:", rwmax
+     svals = 0
      for (val in rwvals) {
        svals += (rwvals[val] - rwavg) ** 2
      }
@@ -83,6 +86,7 @@ cat *-iozone.log | gawk '
      printf "%-7s %6d\n", "mean:", rravg
      printf "%-7s %6d\n", "min:", rrmin
      printf "%-7s %6d\n", "max:", rrmax
+     svals = 0
      for (val in rrvals) {
        svals += (rrvals[val] - rravg) ** 2
      }


### PR DESCRIPTION
If device has been build with LUKS encryption, but empty otherwise, it is similar case as with LVM Volume groups.
Without checking encryption, we get
Unused disks:  /dev/mapper/vg_root-lv_secure,
but in reality it points to  /dev/mapper/enc1 after LUKS setup