### PR TITLE
fixing issue with fdisk GPT message

### DIFF
--- a/pre-install/disk-test.sh
+++ b/pre-install/disk-test.sh
@@ -62,7 +62,7 @@ done
 find_unused_disks() {
    [[ -n "$DBG" ]] && set -x
    disklist=""
-   fdisks=$(fdisk -l |& awk '/^Disk .* bytes/{print $2}' |sort)
+   fdisks=$(fdisk -l 2>/dev/null | awk '/^Disk .* bytes/{print $2}' |sort)
    for d in $fdisks; do
       [[ -n "$DBG" ]] && echo Fdisk list loop, Checking Device: $dev
       dev=${d%:} # Strip colon off the dev path string


### PR DESCRIPTION
In function find_unused_disks() there is a potential bug.
In some situation message from the fdisk about GPT support is delayed:

> WARNING: fdisk GPT support is currently new, and therefore in an experimental phase. Use at your own discretion.

This affecting possibility to do awk on the specific disks

following code:

`fdisks=$(fdisk -l |& awk '/^Disk .* bytes/{print $2}' |sort)`

can be replaced with

`(fdisk -l 2>/dev/null | awk '/^Disk .* bytes/{print $2}' |sort)`